### PR TITLE
Relax the dateutil version requirement.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.13.0
-python-dateutil==2.6.0
+python-dateutil>=2.6.0,<2.7.0
 pytz==2017.2


### PR DESCRIPTION
A project I'm trying to use alongside matchbook requireds dateutil >=2.6.1. This change relaxes matchbook's dateutil version requirement to allow anything between 2.6.0 and 2.7.0, not including 2.7.0. There shouldn't be any breaking changes after 2.6.0 and before 2.7.0, and there don't appear to be any based on the dateutil release notes. I tested matchbook briefly with a call to get market data, with dateutil 2.6.1 installed, and it worked.