### PR TITLE
Add pipenv-related values to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ dist/
 matchbook.egg-info/
 *.log
 *.html
+
+/.python-version
+/Pipfile
+/Pipfile.lock


### PR DESCRIPTION
Ignore files associated with pipenv so that I can use pipenv to manage the library's virtual environment while developing the library.