### PR TITLE
Add sports constants.

### DIFF
--- a/matchbook/enums.py
+++ b/matchbook/enums.py
@@ -368,3 +368,10 @@ class AggregationType:
     Average = 'average'
     Summary = 'summary'
     Default = Average
+
+
+class SportType:
+    """
+    Types of sports.
+    """
+    Sport = "SPORT"

--- a/matchbook/sports.py
+++ b/matchbook/sports.py
@@ -1,0 +1,113 @@
+"""
+Sports as defined by Matchbook.
+"""
+
+from matchbook.enums import SportType
+
+
+class Sport:
+    """
+    A sport as defined by Matchbook.
+    """
+    def __init__(self,  id_, name, type_=SportType.Sport):
+        self.name = name
+        self.type_ = type_
+        self.id_ = id_
+
+
+AmericanFootball = Sport(1, 'American Football')
+Athletics = Sport(555636871580009, 'Athletics')
+AustralianRules = Sport(112, 'Australian Rules')
+Baseball = Sport(3, 'Baseball')
+Basketball = Sport(4, 'Basketball')
+Boxing = Sport(14, 'Boxing')
+Cricket = Sport(110, 'Cricket')
+CurrentEvents = Sport(11, 'Current Events')
+Cycling = Sport(115, 'Cycling')
+Darts = Sport(116, 'Darts')
+GaelicFootball = Sport(117, 'Gaelic Football')
+Golf = Sport(8, 'Golf')
+GreyhoundRacing = Sport(241798357140019, 'Greyhound Racing')
+HorseRacing = Sport(24735152712200, 'Horse Racing')
+HorseRacingAntePost = Sport(222109340250019, 'Horse Racing (Ante Post)')
+HorseRacingBeta = Sport(231138347942400, 'Horse Racing Beta')
+Hurling = Sport(118, 'Hurling')
+IceHockey = Sport(6, 'Ice Hockey')
+Mma = Sport(126, 'MMA')
+MotorSport = Sport(13, 'Motor Sport')
+NcaaBasketball = Sport(5, 'NCAA Basketball')
+NcaaFootball = Sport(2, 'NCAA Football')
+Politics = Sport(385227477790005, 'Politics')
+RugbyLeague = Sport(114, 'Rugby League')
+RugbyUnion = Sport(18, 'Rugby Union')
+Snooker = Sport(120, 'Snooker')
+Soccer = Sport(15, 'Soccer')
+TvSpecials = Sport(670369566180014, 'TV Specials')
+Tennis = Sport(9, 'Tennis')
+TestSport = Sport(502491395980009, 'Test Sport')
+ESports = Sport(123, 'eSports')
+
+All = [
+    AmericanFootball,
+    Athletics,
+    AustralianRules,
+    Baseball,
+    Basketball,
+    Boxing,
+    Cricket,
+    CurrentEvents,
+    Cycling,
+    Darts,
+    GaelicFootball,
+    Golf,
+    GreyhoundRacing,
+    HorseRacing,
+    HorseRacingAntePost,
+    HorseRacingBeta,
+    Hurling,
+    IceHockey,
+    Mma,
+    MotorSport,
+    NcaaBasketball,
+    NcaaFootball,
+    Politics,
+    RugbyLeague,
+    RugbyUnion,
+    Snooker,
+    Soccer,
+    TvSpecials,
+    Tennis,
+    TestSport,
+    ESports,
+]
+
+_ID_SPORT_MAP = {
+    sport.id_: sport for sport in All
+}
+
+
+def from_id(id_):
+    """
+    Gets a sport by its ID.
+    :param id_: The sport's ID.
+    :return: The sport.
+    """
+    return _ID_SPORT_MAP[id_]
+
+
+def test(referencedata_path):
+    import ast
+
+    with open(referencedata_path) as f:
+        sports_data = f.read()
+        sports_data = ast.literal_eval(sports_data)
+        sports_list = sports_data['sports']
+        assert len(sports_list) == len(All)
+        for sport_json in sports_list:
+            sport_id = sport_json['id']
+            sport = from_id(sport_id)
+            assert sport_json['id'] == sport.id_
+            assert sport_json['name'] == sport.name
+            assert sport_json['type'] == sport.type_
+
+    print('test passed.')

--- a/matchbook/tests/resources/referencedata_sports.json
+++ b/matchbook/tests/resources/referencedata_sports.json
@@ -1,33 +1,162 @@
-{'offset': 0,
- 'per-page': 500,
- 'sports': [{'id': 1, 'name': 'American Football', 'type': 'SPORT'},
-  {'id': 555636871580009, 'name': 'Athletics', 'type': 'SPORT'},
-  {'id': 112, 'name': 'Australian Rules', 'type': 'SPORT'},
-  {'id': 13, 'name': 'Auto Racing', 'type': 'SPORT'},
-  {'id': 3, 'name': 'Baseball', 'type': 'SPORT'},
-  {'id': 4, 'name': 'Basketball', 'type': 'SPORT'},
-  {'id': 14, 'name': 'Boxing', 'type': 'SPORT'},
-  {'id': 110, 'name': 'Cricket', 'type': 'SPORT'},
-  {'id': 11, 'name': 'Current Events', 'type': 'SPORT'},
-  {'id': 115, 'name': 'Cycling', 'type': 'SPORT'},
-  {'id': 116, 'name': 'Darts', 'type': 'SPORT'},
-  {'id': 117, 'name': 'Gaelic Football', 'type': 'SPORT'},
-  {'id': 8, 'name': 'Golf', 'type': 'SPORT'},
-  {'id': 241798357140019, 'name': 'Greyhound Racing', 'type': 'SPORT'},
-  {'id': 24735152712200, 'name': 'Horse Racing', 'type': 'SPORT'},
-  {'id': 222109340250019, 'name': 'Horse Racing (Ante Post)', 'type': 'SPORT'},
-  {'id': 231138347942400, 'name': 'Horse Racing Beta', 'type': 'SPORT'},
-  {'id': 118, 'name': 'Hurling', 'type': 'SPORT'},
-  {'id': 6, 'name': 'Ice Hockey', 'type': 'SPORT'},
-  {'id': 126, 'name': 'MMA', 'type': 'SPORT'},
-  {'id': 5, 'name': 'NCAA Basketball', 'type': 'SPORT'},
-  {'id': 2, 'name': 'NCAA Football', 'type': 'SPORT'},
-  {'id': 385227477790005, 'name': 'Politics', 'type': 'SPORT'},
-  {'id': 114, 'name': 'Rugby League', 'type': 'SPORT'},
-  {'id': 18, 'name': 'Rugby Union', 'type': 'SPORT'},
-  {'id': 120, 'name': 'Snooker', 'type': 'SPORT'},
-  {'id': 15, 'name': 'Soccer', 'type': 'SPORT'},
-  {'id': 9, 'name': 'Tennis', 'type': 'SPORT'},
-  {'id': 502491395980009, 'name': 'Test Sport', 'type': 'SPORT'},
-  {'id': 123, 'name': 'eSports', 'type': 'SPORT'}],
- 'total': 30}
+{
+  'total':31,
+  'per-page':500,
+  'offset':0,
+  'sports':[
+    {
+      'name':'American Football',
+      'id':1,
+      'type':'SPORT'
+    },
+    {
+      'name':'Athletics',
+      'id':555636871580009,
+      'type':'SPORT'
+    },
+    {
+      'name':'Australian Rules',
+      'id':112,
+      'type':'SPORT'
+    },
+    {
+      'name':'Baseball',
+      'id':3,
+      'type':'SPORT'
+    },
+    {
+      'name':'Basketball',
+      'id':4,
+      'type':'SPORT'
+    },
+    {
+      'name':'Boxing',
+      'id':14,
+      'type':'SPORT'
+    },
+    {
+      'name':'Cricket',
+      'id':110,
+      'type':'SPORT'
+    },
+    {
+      'name':'Current Events',
+      'id':11,
+      'type':'SPORT'
+    },
+    {
+      'name':'Cycling',
+      'id':115,
+      'type':'SPORT'
+    },
+    {
+      'name':'Darts',
+      'id':116,
+      'type':'SPORT'
+    },
+    {
+      'name':'Gaelic Football',
+      'id':117,
+      'type':'SPORT'
+    },
+    {
+      'name':'Golf',
+      'id':8,
+      'type':'SPORT'
+    },
+    {
+      'name':'Greyhound Racing',
+      'id':241798357140019,
+      'type':'SPORT'
+    },
+    {
+      'name':'Horse Racing',
+      'id':24735152712200,
+      'type':'SPORT'
+    },
+    {
+      'name':'Horse Racing (Ante Post)',
+      'id':222109340250019,
+      'type':'SPORT'
+    },
+    {
+      'name':'Horse Racing Beta',
+      'id':231138347942400,
+      'type':'SPORT'
+    },
+    {
+      'name':'Hurling',
+      'id':118,
+      'type':'SPORT'
+    },
+    {
+      'name':'Ice Hockey',
+      'id':6,
+      'type':'SPORT'
+    },
+    {
+      'name':'MMA',
+      'id':126,
+      'type':'SPORT'
+    },
+    {
+      'name':'Motor Sport',
+      'id':13,
+      'type':'SPORT'
+    },
+    {
+      'name':'NCAA Basketball',
+      'id':5,
+      'type':'SPORT'
+    },
+    {
+      'name':'NCAA Football',
+      'id':2,
+      'type':'SPORT'
+    },
+    {
+      'name':'Politics',
+      'id':385227477790005,
+      'type':'SPORT'
+    },
+    {
+      'name':'Rugby League',
+      'id':114,
+      'type':'SPORT'
+    },
+    {
+      'name':'Rugby Union',
+      'id':18,
+      'type':'SPORT'
+    },
+    {
+      'name':'Snooker',
+      'id':120,
+      'type':'SPORT'
+    },
+    {
+      'name':'Soccer',
+      'id':15,
+      'type':'SPORT'
+    },
+    {
+      'name':'TV Specials',
+      'id':670369566180014,
+      'type':'SPORT'
+    },
+    {
+      'name':'Tennis',
+      'id':9,
+      'type':'SPORT'
+    },
+    {
+      'name':'Test Sport',
+      'id':502491395980009,
+      'type':'SPORT'
+    },
+    {
+      'name':'eSports',
+      'id':123,
+      'type':'SPORT'
+    }
+  ]
+}


### PR DESCRIPTION
Add constants for the values that Matchbook returns from the "sports" endpoint. Matchbook has guaranteed that these values will remain constant; see https://developers.matchbook.com/discuss/5b6a348459beb90003ca2933.

I wasn't sure how to integrate the test with the framework that the rest of the library is using, as I'm unfamiliar with that framework.